### PR TITLE
fix: correct typo in the example CSS syntax

### DIFF
--- a/two.html
+++ b/two.html
@@ -134,7 +134,7 @@
           <li><a href="https://www.quackit.com/css/tutorial/css_syntax.cfm" target="_blank">Syntax</a></li>
         </ul>
         <pre>
-          <code>selector { property: value };</code>
+          <code>selector { property: value; }</code>
         </pre>
         <ul class="points">
           <li>Readability</li>


### PR DESCRIPTION
Closes #2 

Corrected the typo in the example. Example now has `;` in the correct place.