### PR TITLE
Day 3 advanced section matches dark mode theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -264,7 +264,7 @@ aside h2 {
 }
 
 details {
-    background-color: #eee;
+    background-color: var(--default-background-color);
     padding: 10px;
 }
 


### PR DESCRIPTION
### Changes

- Modified `style.css` so the detail element background was being populated by default background var

### Pre-Testing

- [ ] Switch to dark mode

### Testing Steps
To test day 3 advanced section dark mode:
1. Go to day 3
2. Scroll down to advanced section

**Expected result:** Nothing will happen. Fields are no longer clickable when not editing.

### Screenshots

![image](https://user-images.githubusercontent.com/25210542/184464791-9931500d-9413-48b1-bc26-69883dff6c7e.png)


Closes #36 